### PR TITLE
Add command flags to the fast-p binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ The first run of the command will take some time to cache the text extracted fro
 
 # How to clear the cache?
 
-To clear the cache (which contains text extracted from PDF), you may safely remove the file 
-``~/.cache/fast-p-pdftotext-output/fast-p_cached_pdftotext_output.db``, or  
-``~/.cache/fast-p_cached_pdftotext_output.db`` in older version.
+To clear the cache (which contains text extracted from PDF), you can run 'fast-p --clear-cache'. This will safely remove the file located at:
+``~/.cache/fast-p-pdftotext-output/fast-p_cached_pdftotext_output.db``
+
+For older versions, please manually delete the cache file found at
+``~/.cache/fast-p_cached_pdftotext_output.db``
 
 # Launch with keyboard shortcut in Ubuntu
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"flag"
         "path/filepath"
 	"os/exec"
         "bufio"
@@ -32,6 +33,25 @@ func hash_file_xxhash(filePath string) (string, error) {
 }
 
 func main() {
+    version := flag.Bool("version", false, "Display program version")
+    clearCache := flag.Bool("clear-cache", false, "Delete cache file located at: \n~/.cache/fast-p-pdftotext-output/fast-p_cached_pdftotext_output.db")
+    flag.Parse()
+
+    if *version != false {
+        fmt.Printf("v.0.2.4 \nhttps://github.com/bellecp/fast-p\n")
+        os.Exit(0)
+    }
+
+    if *clearCache !=false {
+        removePath, err := homedir.Expand("~/.cache/fast-p-pdftotext-output/fast-p_cached_pdftotext_output.db")
+        if err != nil {
+            log.Fatal(err)
+            os.Exit(1)
+        }
+        os.Remove(removePath)
+        os.Exit(0)
+    }
+
     // Create ~/.cache folder if does not exist
     // https://stackoverflow.com/questions/37932551/mkdir-if-not-exists-using-golang
     cachePath, err := homedir.Expand("~/.cache/fast-p-pdftotext-output/")


### PR DESCRIPTION
--version, --clear-cache, --help (generated automatically by 'flags' module)

I know that generally the fast-p binary won't be called by itself, as most the work is done via the bashrc function. But when installing small tools like this, I like to be able to check for updates every once in awhile, and this is easier to do when running --version and comparing the release tag to the one on github. (Please note that I didn't bump the version in the text of --version, I will leave that to you to decide)

While adding this, I figured a --clear-cache option would be easy enough to add and save some work for users. README is updated accordingly.

Using the flags module, --help is auto-generated and therefore is absent from the code below.

Let me know if you want any changes, or close if you feel it's unneeded

